### PR TITLE
test: login screen으로부터 시작하는 navigation testing

### DIFF
--- a/frontend/app/build.gradle.kts
+++ b/frontend/app/build.gradle.kts
@@ -94,13 +94,13 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.3.3")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.3.3")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.3.3")
 
     // Navigation
-    implementation("androidx.navigation:navigation-compose:2.4.0-alpha10")
-
+    implementation("androidx.navigation:navigation-compose:2.5.3")
+    androidTestImplementation("androidx.navigation:navigation-testing:2.5.3")
     // Gogle Places
     implementation("com.google.android.libraries.places:places:3.1.0")
 
@@ -113,14 +113,11 @@ dependencies {
     implementation ("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
     implementation ("androidx.lifecycle:lifecycle-runtime-compose:2.6.1")
 
-    // Testing Navigation
-    androidTestImplementation ("androidx.navigation:navigation-testing:2.4.0-alpha10")
     // JUnit
     testImplementation ("junit:junit:4.+")
     // MockK (Kotlin-friendly mocking library)
     testImplementation ("io.mockk:mockk:1.12.0")
 
-    androidTestImplementation ("androidx.compose.ui:ui-test-junit4:1.7.0")
     // coil: image upload
     implementation ("io.coil-kt:coil-compose:1.4.0")
 

--- a/frontend/app/src/androidTest/java/com/team13/fooriend/NavigationTest.kt
+++ b/frontend/app/src/androidTest/java/com/team13/fooriend/NavigationTest.kt
@@ -1,0 +1,89 @@
+package com.team13.fooriend
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import com.team13.fooriend.core.graph.AuthScreen
+import com.team13.fooriend.core.graph.Graph
+import com.team13.fooriend.core.graph.RootNavigationGraph
+import com.team13.fooriend.ui.screen.login.LogInScreen
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+    lateinit var navController: TestNavHostController
+
+    @Before
+    fun setUpNavHost(){
+        composeTestRule.setContent {
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            RootNavigationGraph(navController = navController, context = LocalContext.current)
+        }
+    }
+
+    @Test
+    fun verify_StartDestinationIsLoginScreen(){
+        composeTestRule
+            .onNodeWithText("LOGIN")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun performClick_OnSignUpButton_navigatesToSignUpScreen(){
+        composeTestRule
+            .onNodeWithText("SIGN UP")
+            .performClick()
+        val route = navController.currentBackStackEntry?.destination?.route
+        Assert.assertEquals(route, AuthScreen.SignUp.route)
+    }
+
+    @Test
+    fun performClick_OnLogInButton_withEmptyIDandPWD(){
+        composeTestRule
+            .onNodeWithText("LOGIN")
+            .performClick()
+        val route = navController.currentBackStackEntry?.destination?.route
+        Assert.assertEquals(route, AuthScreen.Login.route)
+    }
+
+    @Test
+    fun performClick_OnLogInButton_withWrongIDorPWD(){
+        composeTestRule
+            .onNodeWithText("ID")
+            .performTextInput("admin")
+        composeTestRule
+            .onNodeWithText("PASSWORD")
+            .performTextInput("admin") // please change wrong pwd
+        composeTestRule
+            .onNodeWithText("LOGIN")
+            .performClick()
+        val route = navController.currentBackStackEntry?.destination?.route
+        Assert.assertEquals(route, AuthScreen.Login.route)
+    }
+
+    @Test
+    fun performClick_OnLogInButton_withCorrectIDandPWD(){
+        composeTestRule
+            .onNodeWithText("ID")
+            .performTextInput("admin")
+        composeTestRule
+            .onNodeWithText("PASSWORD")
+            .performTextInput("admin")
+        composeTestRule
+            .onNodeWithText("LOGIN")
+            .performClick()
+        val route = navController.currentBackStackEntry?.destination?.route
+        Assert.assertEquals(route, Graph.HOME)
+    }
+}


### PR DESCRIPTION
login screen으로부터 이동할 수 있는 navigation testing code 들입니다. -처음 앱 시작시 login screen인지 확인
-SIGN UP 버튼 클릭 sign up screen으로 이동하는지 확인
-ID/PWD 입력 하지 않고 LOGIN 버튼 클릭시 화면 전환 없는지 확인
-잘못된 ID/PWD 입력하고 LOGIN 버튼 클릭시 화면 전환 없는지 확인
-올바른 ID/PWD 입력하고 LOGIN 버튼 클릭시 HOME route로 이동하는지 확인